### PR TITLE
refactor: Rename Nest to AssetsNest to avoid naming conflicts between he module and class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ https://github.com/yyjim/Nest
 Nest provides a convenient shared instance that uses `LocalStorage` for file management and `CoreData` for asset metadata management:
 
 ```swift
-let nest = Nest.localShared
+let nest = AssetsNest.sharedLocal
 ```
 
 **Custom Initialization**
@@ -48,7 +48,7 @@ If you want to use a custom storage or database implementation, you can initiali
 let customStorage: NestStorage = CustomNestStorage()
 let customDatabase: NestDatabase = CustomNestDatabase()
 
-let nest = Nest(storage: customStorage, database: customDatabase)
+let nest = AssetsNest(storage: customStorage, database: customDatabase)
 ````
 
 ## Asset Management

--- a/Sources/Nest/AssetsNest+Image.swift
+++ b/Sources/Nest/AssetsNest+Image.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-extension Nest {
+extension AssetsNest {
     /// Saves a `UIImage` with the specified format.
     /// - Parameters:
     ///   - image: The `UIImage` to save.

--- a/Sources/Nest/AssetsNest.swift
+++ b/Sources/Nest/AssetsNest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class Nest: @unchecked Sendable {
+public class AssetsNest: @unchecked Sendable {
     private let storage: NestStorage
     private let database: NestDatabase
 
@@ -29,10 +29,10 @@ public class Nest: @unchecked Sendable {
     }
 
     /// Shared instance using `LocalStorage` and CoreData.
-    public static let localShared: Nest = {
+    public static let sharedLocal: AssetsNest = {
         let storage = LocalStorage(directory: .documents)
         let database = CoreDataAssetDatabase(context: CoreDataManager.shared.context)
-        return Nest(storage: storage, database: database)
+        return AssetsNest(storage: storage, database: database)
     }()
 
     /// Initializes the `Nest` framework with the provided storage and database implementations.

--- a/Tests/NestTests/AssetsNestTests.swift
+++ b/Tests/NestTests/AssetsNestTests.swift
@@ -3,17 +3,17 @@ import UIKit
 import Foundation
 @testable import Nest
 
-extension Nest {
-    static let mock: Nest = {
+extension AssetsNest {
+    static let mock: AssetsNest = {
         let storage = MockStorage()
         let database = MockDatabase()
-        return Nest(storage: storage, database: database)
+        return AssetsNest(storage: storage, database: database)
     }()
 }
 
 @Test
 func testFetchAssets() async throws {
-    let nest = Nest.localShared
+    let nest = AssetsNest.sharedLocal
     try await nest.deleteAllAssets()
     #expect(try! nest.fetchAllAssets().isEmpty)
 
@@ -37,17 +37,17 @@ func testFetchAssets() async throws {
     #expect(try! nest.fetchAllAssets().count == 20 + 10 + 5)
 }
 
-@Test func testNestCURD() async throws {
-    // NOTE: The @Test(arguments: [Nest.localShared, Nest.mock]) doesn't work, so we have to test them separately
-    // Test with Nest.Mock
-    try await performCURDTest(using: Nest.mock)
+@Test func testAssetsNestCURD() async throws {
+    // NOTE: The @Test(arguments: [AssetsNest.sharedLocal, AssetsNest.mock]) doesn't work, so we have to test them separately
+    // Test with AssetsNest.Mock
+    try await performCURDTest(using: AssetsNest.mock)
 
-    // Test with Nest.localShared
-    try await performCURDTest(using: Nest.localShared)
+    // Test with AssetsNest.sharedLocal
+    try await performCURDTest(using: AssetsNest.sharedLocal)
 }
 
 // Helper function to perform CURD test
-private func performCURDTest(using nest: Nest) async throws {
+private func performCURDTest(using nest: AssetsNest) async throws {
     try await nest.deleteAllAssets()
     #expect(try! nest.fetchAllAssets().count == 0)
 
@@ -82,15 +82,15 @@ private func performCURDTest(using nest: Nest) async throws {
 }
 
 @Test func testImageCURD() async throws {
-    // Test with Nest.Mock
-    try await performImageCURDTest(using: Nest.mock)
+    // Test with AssetsNest.Mock
+    try await performImageCURDTest(using: AssetsNest.mock)
 
-    // Test with Nest.localShared
-    try await performImageCURDTest(using: Nest.localShared)
+    // Test with AssetsNest.sharedLocal
+    try await performImageCURDTest(using: AssetsNest.sharedLocal)
 }
 
 // Helper function to perform CURD test for images
-private func performImageCURDTest(using nest: Nest) async throws {
+private func performImageCURDTest(using nest: AssetsNest) async throws {
     func generateTestImage(size: CGSize = CGSize(width: 10, height: 10), color: UIColor = .blue) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, false, 1.0)
         defer { UIGraphicsEndImageContext() }


### PR DESCRIPTION
# Description

refactor: Rename Nest to AssetsNest to avoid naming conflicts between he module and class names

# Screenshots

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

... add the demo screenshots or videos here ...

</td>
<td>

... add the demo screenshots or videos here ...

</td>
</tr>
</table>